### PR TITLE
Feature init discovery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ dkpswitch-*
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# Hidden version file we write ourselves
+.dkp
+
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ You can provide this token via the command line (if `dkpswitch` does not find an
 
 Alternately, for a more permanent solution, you can set the environment variable `GITHUB_PERSONAL_ACCESS_TOKEN` in your shell environment file (e.g. `~/.bashrc` or `~/.zshrc`).
 
+### Initialize in directory
+
+If you have used this tool previously to set your version of DKP/Konvoy, a `.dkp` file will have been written in the directory.
+
+`dkpswitch init` will initialize `dkp`/`konvoy` in the present directory.  If no `.dkp` file is found, you will be provided a list of versions to choose from.  If a `.dkp` file is present, `dkpswitch` will initialize the version found within that file (i.e. the version that was previously used)
+
 ### Pick version from a list
 
 `dkpswitch list` will reach out and query the GitHub API for all GA releases of DKP, and present them to the user in an interactive list.  Items may be selected by navigating with the arrow keys and pressing the `Enter` key once their desired version is highlighted.
@@ -27,9 +33,9 @@ If you do not explicitly specify `all`, only GA releases will be shown.
 
 ### Specify a specific version
 
-If you already know the desired DKP version you wish to use, simply skip the list and specify it directly with `dkpswitch init <version>`.  To use DKP v2.1.1, either:
-- `dkpswitch init 2.1.1`
-- `dkpswitch init v2.1.1`
+If you already know the desired DKP version you wish to use, simply skip the list and specify it directly with `dkpswitch <version>`.  To use DKP v2.1.1, either:
+- `dkpswitch 2.1.1`
+- `dkpswitch v2.1.1`
 
 may be provided.
 


### PR DESCRIPTION
Added feature to write to and read from a local hidden file named `.dkp`.  This ensures that if you have used `dkpswitch` to set your DKP/Konvoy version, and then used that binary to create resources or spin up clusters, you will have a record of exactly which version was used in that directory.

`dkpswitch init` will look for a `.dkp` file and attempt to switch to the version inside that file.  If no `.dkp` file is found, you will be asked to pick from a list.